### PR TITLE
Removed double arguments on 'ME'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ export class LinkedinAuth extends OAuth2Strategy {
   public static getLiteProfile(accessToken: string,
                                done: (err?: (Error | null), profile?: any) => void) {
     request.get(
-      ME + '?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
+      ME,
       { headers: LinkedinAuth.getHeader(accessToken) },
       (error: any, response: request.Response, body: any) => {
         if (error) {


### PR DESCRIPTION
If i run it it throws 
```Unexpected trailing input: '?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))'```

So i realised it was because ME was already assigned with the get parameters